### PR TITLE
Fix source code not displaying for implicit and deterministic accounts

### DIFF
--- a/pages/code/[slug].tsx
+++ b/pages/code/[slug].tsx
@@ -1,7 +1,7 @@
 import FileSelectionDrawer from '@/components/Code/FileSelectionDrawer'
 import PageHead from '@/components/Common/PageHead'
 import { useNetwork } from '@/contexts/NetworkContext'
-import { detectNetworkFromAddress } from '@/utils/detectNetwork'
+import { detectNetworkFromAddress, isValidNearAccount } from '@/utils/detectNetwork'
 import { ascii_to_str } from '@/utils/near/ascii_converter'
 import { useRpcUrl } from '@/utils/near/rpc'
 import { bg, color } from '@/utils/theme'
@@ -39,14 +39,11 @@ export default function Code() {
   // Step 1: Detect network from contract address and switch if necessary
   useEffect(() => {
     if (accountId) {
-      // Check if the TLD is valid (.near or .testnet)
-      const isValidTLD =
-        accountId.endsWith('.near') || accountId.endsWith('.testnet')
-      if (!isValidTLD) {
-        console.log(`Code page: Invalid TLD for contract: ${accountId}`)
+      if (!isValidNearAccount(accountId)) {
+        console.log(`Code page: Invalid account ID: ${accountId}`)
         setLoading(false)
         setErrorMessage(
-          `Invalid contract address: ${accountId}. Contract addresses must end with .near or .testnet`
+          `Invalid contract address: ${accountId}. Must be a named account (.near/.testnet) or an implicit/deterministic account.`
         )
         return
       }
@@ -438,14 +435,11 @@ export default function Code() {
   // Update the TLD validation to set the invalidTLD state
   useEffect(() => {
     if (accountId) {
-      // Check if the TLD is valid (.near or .testnet)
-      const isValidTLD =
-        accountId.endsWith('.near') || accountId.endsWith('.testnet')
-      if (!isValidTLD) {
-        console.log(`Code page: Invalid TLD for contract: ${accountId}`)
+      if (!isValidNearAccount(accountId)) {
+        console.log(`Code page: Invalid account ID: ${accountId}`)
         setLoading(false)
         setErrorMessage(
-          `Invalid contract address: ${accountId}. Contract addresses must end with .near or .testnet`
+          `Invalid contract address: ${accountId}. Must be a named account (.near/.testnet) or an implicit/deterministic account.`
         )
         setInvalidTLD(true)
         return
@@ -491,7 +485,8 @@ export default function Code() {
               textAlign="center"
               maxW="600px"
             >
-              Contract addresses must end with .near or .testnet
+              Must be a named account (.near/.testnet) or an
+              implicit/deterministic account.
             </Text>
           </Flex>
         ) : loading ? (

--- a/pages/contract/[slug].tsx
+++ b/pages/contract/[slug].tsx
@@ -1,6 +1,6 @@
 import { GithubDto } from '@/Interfaces/github/github.dto'
 import { useNetwork } from '@/contexts/NetworkContext'
-import { detectNetworkFromAddress } from '@/utils/detectNetwork'
+import { detectNetworkFromAddress, isValidNearAccount } from '@/utils/detectNetwork'
 import { extractGitHubDetails } from '@/utils/extractGithub'
 import { ascii_to_str } from '@/utils/near/ascii_converter'
 import { useRpcUrl } from '@/utils/near/rpc'
@@ -248,11 +248,8 @@ export default function Contract() {
   // Step 1: Detect network from contract address and switch if necessary
   useEffect(() => {
     if (accountId) {
-      // Check if the TLD is valid (.near or .testnet)
-      const isValidTLD =
-        accountId.endsWith('.near') || accountId.endsWith('.testnet')
-      if (!isValidTLD) {
-        console.log(`Invalid TLD for contract: ${accountId}`)
+      if (!isValidNearAccount(accountId)) {
+        console.log(`Invalid account ID: ${accountId}`)
         setLoading(false)
         setInvalidTLD(true)
         return
@@ -282,7 +279,8 @@ export default function Contract() {
                 Invalid contract address: {accountId}
               </Text>
               <Text color="gray.500">
-                Contract addresses must end with .near or .testnet
+                Must be a named account (.near/.testnet) or an
+                implicit/deterministic account.
               </Text>
             </Stack>
           ) : data ? (

--- a/utils/detectNetwork.ts
+++ b/utils/detectNetwork.ts
@@ -1,34 +1,48 @@
 import { NetworkType } from '@/contexts/NetworkContext'
 
 /**
- * Detects the network type from a contract address based on its TLD
- * @param contractAddress The contract address to analyze
- * @returns The detected network type or null if can't be determined
+ * Checks whether an address is a valid NEAR implicit-style account:
+ * - NEAR implicit account: 64 lowercase hex characters
+ * - ETH implicit account: 0x + 40 lowercase hex characters
+ * - NEAR deterministic account: 0s + 40 lowercase hex characters
+ */
+export const isImplicitAccount = (address: string): boolean => {
+  if (!address) return false
+  return (
+    /^[0-9a-f]{64}$/.test(address) ||
+    /^0x[0-9a-f]{40}$/.test(address) ||
+    /^0s[0-9a-f]{40}$/.test(address)
+  )
+}
+
+/**
+ * Detects the network type from a contract address based on its TLD.
+ * Returns null for implicit/deterministic accounts since they can exist on either network.
  */
 export const detectNetworkFromAddress = (
   contractAddress: string
 ): NetworkType | null => {
   if (!contractAddress) return null
 
-  // Check if the address ends with .near (mainnet) or .testnet (testnet)
   if (contractAddress.endsWith('.near')) {
     return 'mainnet'
   } else if (contractAddress.endsWith('.testnet')) {
     return 'testnet'
   }
 
-  // If no specific TLD is found, return null
+  // Implicit and deterministic accounts can exist on either network
   return null
 }
 
 /**
- * Checks if a contract address has a valid NEAR TLD (.near or .testnet)
- * @param contractAddress The contract address to check
- * @returns Boolean indicating if the address has a valid TLD
+ * Checks if a contract address is a valid NEAR account identifier.
+ * Accepts named accounts (.near/.testnet) and implicit/deterministic accounts.
  */
-export const hasValidTLD = (contractAddress: string): boolean => {
+export const isValidNearAccount = (contractAddress: string): boolean => {
   if (!contractAddress) return false
   return (
-    contractAddress.endsWith('.near') || contractAddress.endsWith('.testnet')
+    contractAddress.endsWith('.near') ||
+    contractAddress.endsWith('.testnet') ||
+    isImplicitAccount(contractAddress)
   )
 }


### PR DESCRIPTION
## Summary

- The TLD validation in the `/contract/[slug]` and `/code/[slug]` pages rejects any account ID that doesn't end with `.near` or `.testnet`, which blocks all implicit and deterministic account types from ever reaching the data-fetching code path
- Verified that the on-chain data *does* exist for these accounts (e.g. `0sa8247564c6774a33b975a053fc4fbebbd869772d` returns CID, code hash, lang from `get_contract`), and the IPFS source files are accessible — the frontend just refuses to show them
- Replaced the strict `.near`/`.testnet` suffix check with `isValidNearAccount()` which recognizes all four NEAR account types from `near-account-id` 2.0: named accounts, NEAR implicit (64-char hex), ETH implicit (`0x` + 40 hex), and deterministic (`0s` + 40 hex)

## Context

Reported in [this Slack thread](https://nearone.slack.com/archives/C0A64SAMDNG/p1773326314955379) — a user verified a global deployer contract at a deterministic account ID but the source code isn't visible on SourceScan.

## Test plan

- [x] `isValidNearAccount` accepts `0s` + 40 hex (deterministic), `0x` + 40 hex (ETH implicit), 64-char hex (NEAR implicit), `.near`, `.testnet`
- [x] `isValidNearAccount` rejects garbage strings, short hex, uppercase hex, empty strings
- [x] Queried `get_contract` for `0sa8247564c6774a33b975a053fc4fbebbd869772d` via local proxy → returns valid CID/code_hash/lang
- [x] IPFS structure endpoint returns source files for the returned CID
- [x] `/contract/0sa824...` and `/code/0sa824...` pages proceed to loading state instead of showing "Invalid contract address"
- [x] `next build` succeeds, `next lint` has no new warnings