### PR TITLE
fix(frontend): align source snapshot parsing

### DIFF
--- a/utils/extractGithub.ts
+++ b/utils/extractGithub.ts
@@ -1,24 +1,96 @@
 function extractGitHubDetails(url: string) {
-  // Remove the protocol (https://) and domain (github.com/)
-  const cleanUrl = url.replace(/^git\+/, '')
+  if (typeof url !== 'string' || !url.startsWith('git+')) {
+    throw new Error('Source snapshot must use git+ URL format')
+  }
 
-  // Extract the base URL and the query parameters
-  const [baseUrl, queryParams] = cleanUrl.split('?')
+  const sourceSnapshot = url.replace(/^git\+/, '')
+  const { repoUrl, sha } = parseGitSnapshot(sourceSnapshot)
 
-  // Remove the '.git' suffix from the base URL
-  const cleanBaseUrl = baseUrl.replace(/\.git$/, '')
+  if (!/^[0-9a-f]{40}$/i.test(sha)) {
+    throw new Error('Source snapshot must pin a full 40-character commit SHA')
+  }
 
-  // Split the base URL to extract owner and repo
-  const parts = cleanBaseUrl.replace(/^https?:\/\/github\.com\//, '').split('/')
+  const githubPath = getGithubPath(repoUrl)
+  const [owner, repo] = githubPath
+    .replace(/^\/+|\/+$/g, '')
+    .replace(/\.git$/, '')
+    .split('/')
 
-  const owner = parts[0]
-  const repo = parts[1]
-
-  // Extract the SHA from the query parameters
-  const params = new URLSearchParams(queryParams)
-  const sha = params.get('rev')!
+  if (!owner || !repo) {
+    throw new Error('Source snapshot must point to a GitHub repository')
+  }
 
   return { owner, repo, sha }
+}
+
+function parseGitSnapshot(snapshot: string): {
+  repoUrl: string
+  sha: string
+} {
+  if (snapshot.startsWith('git@github.com:')) {
+    return parseScpLikeGithubSnapshot(snapshot)
+  }
+
+  const snapshotUrl = new URL(snapshot)
+
+  if (snapshotUrl.hostname !== 'github.com') {
+    throw new Error('Source snapshot must point to a GitHub repository')
+  }
+
+  const revSha = snapshotUrl.searchParams.get('rev')
+  const hashSha = snapshotUrl.hash
+    ? decodeURIComponent(snapshotUrl.hash.slice(1))
+    : null
+
+  if (revSha && hashSha && revSha !== hashSha) {
+    throw new Error('Source snapshot must not contain conflicting commit SHAs')
+  }
+
+  snapshotUrl.search = ''
+  snapshotUrl.hash = ''
+
+  return {
+    repoUrl: snapshotUrl.toString(),
+    sha: revSha || hashSha || '',
+  }
+}
+
+function parseScpLikeGithubSnapshot(snapshot: string): {
+  repoUrl: string
+  sha: string
+} {
+  const revMarker = '?rev='
+  const revIndex = snapshot.indexOf(revMarker)
+  const hashIndex = snapshot.indexOf('#')
+
+  if (revIndex === -1 && hashIndex === -1) {
+    throw new Error('Source snapshot must pin a full 40-character commit SHA')
+  }
+
+  if (revIndex !== -1) {
+    const repoUrl = snapshot.slice(0, revIndex)
+    const shaWithPossibleHash = snapshot.slice(revIndex + revMarker.length)
+    const [revSha, hashSha] = shaWithPossibleHash.split('#')
+
+    if (hashSha && revSha !== hashSha) {
+      throw new Error('Source snapshot must not contain conflicting commit SHAs')
+    }
+
+    return { repoUrl, sha: revSha }
+  }
+
+  return {
+    repoUrl: snapshot.slice(0, hashIndex),
+    sha: snapshot.slice(hashIndex + 1),
+  }
+}
+
+function getGithubPath(repoUrl: string): string {
+  if (repoUrl.startsWith('git@github.com:')) {
+    return repoUrl.slice('git@github.com:'.length)
+  }
+
+  return new URL(repoUrl).pathname
 }
 
 export { extractGitHubDetails }


### PR DESCRIPTION
## Summary

- Parse NEP-330 GitHub source snapshots using either ?rev=<sha> or #<sha>.
- Require full 40-character commit SHAs before rendering GitHub links.
- Reject non-GitHub source snapshots for the GitHub link helper instead of deriving bogus owner/repo values.

## Validation

- Disposable Docker container (node:22-alpine, repo mounted read-only then copied inside): npm ci --ignore-scripts --no-audit --no-fund && npm run lint && npm run build
- Disposable Docker parser behavior check for ?rev, #sha, GitHub SSH, SCP-like GitHub, branch/short-SHA rejection, non-GitHub rejection
- git diff --check