### PR TITLE
fix(frontend): align account id validation

### DIFF
--- a/pages/code/[slug].tsx
+++ b/pages/code/[slug].tsx
@@ -43,7 +43,7 @@ export default function Code() {
         console.log(`Code page: Invalid account ID: ${accountId}`)
         setLoading(false)
         setErrorMessage(
-          `Invalid contract address: ${accountId}. Must be a named account (.near/.testnet) or an implicit/deterministic account.`
+          `Invalid contract address: ${accountId}. Must be a valid NEAR account ID.`
         )
         return
       }
@@ -64,6 +64,8 @@ export default function Code() {
   // Mark network detection as complete after a network change
   useEffect(() => {
     if (accountId && !networkDetected) {
+      if (!isValidNearAccount(accountId)) return
+
       const detectedNetwork = detectNetworkFromAddress(accountId)
       if (!detectedNetwork || detectedNetwork === network) {
         setNetworkDetected(true)
@@ -73,7 +75,14 @@ export default function Code() {
 
   // Step 2: Add timeout to prevent infinite loading and only fetch after network detection
   useEffect(() => {
-    if (!accountId || !networkConfig || !networkDetected) return
+    if (
+      !accountId ||
+      !networkConfig ||
+      !networkDetected ||
+      !isValidNearAccount(accountId)
+    ) {
+      return
+    }
 
     // Create a timeout to ensure loading isn't stuck forever
     const timeoutId = setTimeout(() => {
@@ -87,7 +96,14 @@ export default function Code() {
   }, [loading, accountId, networkConfig])
 
   useEffect(() => {
-    if (!accountId || !networkConfig || !networkDetected) return
+    if (
+      !accountId ||
+      !networkConfig ||
+      !networkDetected ||
+      !isValidNearAccount(accountId)
+    ) {
+      return
+    }
 
     console.log(
       `Code page: Fetching contract data for ${accountId} on ${networkConfig.name}`
@@ -149,7 +165,9 @@ export default function Code() {
   }, [accountId, rpcUrl, networkConfig, networkDetected])
 
   useEffect(() => {
-    if (!data || !networkConfig) return
+    if (!data || !networkConfig || !accountId || !isValidNearAccount(accountId)) {
+      return
+    }
 
     // Fetch the contract metadata and code hash
     axios
@@ -429,21 +447,22 @@ export default function Code() {
     setSelectedFilePath(path)
   }
 
-  // Add a state for invalid TLD error
-  const [invalidTLD, setInvalidTLD] = useState(false)
+  const [invalidAccountId, setInvalidAccountId] = useState(false)
 
-  // Update the TLD validation to set the invalidTLD state
   useEffect(() => {
     if (accountId) {
       if (!isValidNearAccount(accountId)) {
         console.log(`Code page: Invalid account ID: ${accountId}`)
         setLoading(false)
         setErrorMessage(
-          `Invalid contract address: ${accountId}. Must be a named account (.near/.testnet) or an implicit/deterministic account.`
+          `Invalid contract address: ${accountId}. Must be a valid NEAR account ID.`
         )
-        setInvalidTLD(true)
+        setInvalidAccountId(true)
         return
       }
+
+      setInvalidAccountId(false)
+      setErrorMessage(null)
 
       const detectedNetwork = detectNetworkFromAddress(accountId)
       if (detectedNetwork && detectedNetwork !== network) {
@@ -462,7 +481,7 @@ export default function Code() {
     <>
       <PageHead title={'SourceScan CodeView'} />
       <Stack position="relative" width="100%" minHeight="calc(100vh - 200px)">
-        {invalidTLD ? (
+        {invalidAccountId ? (
           <Flex
             justify="center"
             align="center"
@@ -485,8 +504,7 @@ export default function Code() {
               textAlign="center"
               maxW="600px"
             >
-              Must be a named account (.near/.testnet) or an
-              implicit/deterministic account.
+              Must be a valid NEAR account ID.
             </Text>
           </Flex>
         ) : loading ? (

--- a/pages/contract/[slug].tsx
+++ b/pages/contract/[slug].tsx
@@ -51,6 +51,8 @@ export default function Contract() {
   // Mark network detection as complete after a network change
   useEffect(() => {
     if (accountId && !networkDetected) {
+      if (!isValidNearAccount(accountId)) return
+
       const detectedNetwork = detectNetworkFromAddress(accountId)
       if (!detectedNetwork || detectedNetwork === network) {
         setNetworkDetected(true)
@@ -60,7 +62,14 @@ export default function Contract() {
 
   // Step 2: Only fetch data after network detection is complete
   useEffect(() => {
-    if (!accountId || !networkConfig || !networkDetected) return
+    if (
+      !accountId ||
+      !networkConfig ||
+      !networkDetected ||
+      !isValidNearAccount(accountId)
+    ) {
+      return
+    }
 
     console.log(
       `Fetching contract data for ${accountId} on ${networkConfig.name}`
@@ -119,7 +128,9 @@ export default function Contract() {
   }, [accountId, rpcUrl, networkConfig, networkDetected])
 
   useEffect(() => {
-    if (!data || !networkConfig) return
+    if (!data || !networkConfig || !accountId || !isValidNearAccount(accountId)) {
+      return
+    }
 
     axios
       .post(
@@ -242,8 +253,7 @@ export default function Contract() {
   // No need for toast messages anymore,
   // since we're displaying error information inline
 
-  // Add a state for invalid TLD error
-  const [invalidTLD, setInvalidTLD] = useState(false)
+  const [invalidAccountId, setInvalidAccountId] = useState(false)
 
   // Step 1: Detect network from contract address and switch if necessary
   useEffect(() => {
@@ -251,9 +261,11 @@ export default function Contract() {
       if (!isValidNearAccount(accountId)) {
         console.log(`Invalid account ID: ${accountId}`)
         setLoading(false)
-        setInvalidTLD(true)
+        setInvalidAccountId(true)
         return
       }
+
+      setInvalidAccountId(false)
 
       const detectedNetwork = detectNetworkFromAddress(accountId)
       if (detectedNetwork && detectedNetwork !== network) {
@@ -273,14 +285,13 @@ export default function Contract() {
       <PageHead title={'SourceScan'} />
       <PageRefresh>
         <Stack align={'center'} justify={'center'} spacing={10} pb={100}>
-          {invalidTLD ? (
+          {invalidAccountId ? (
             <Stack spacing={4} align="center">
               <Text color="red.500" fontSize="lg" fontWeight="medium">
                 Invalid contract address: {accountId}
               </Text>
               <Text color="gray.500">
-                Must be a named account (.near/.testnet) or an
-                implicit/deterministic account.
+                Must be a valid NEAR account ID.
               </Text>
             </Stack>
           ) : data ? (

--- a/utils/detectNetwork.ts
+++ b/utils/detectNetwork.ts
@@ -1,18 +1,16 @@
-import { NetworkType } from '@/contexts/NetworkContext'
+import type { NetworkType } from '@/contexts/NetworkContext'
 
 /**
- * Checks whether an address is a valid NEAR implicit-style account:
- * - NEAR implicit account: 64 lowercase hex characters
- * - ETH implicit account: 0x + 40 lowercase hex characters
- * - NEAR deterministic account: 0s + 40 lowercase hex characters
+ * Matches the same account-id shape accepted by the verifier backend.
+ * This includes named accounts, 64-character implicit accounts, and
+ * 0x/0s-prefixed deterministic account strings.
  */
-export const isImplicitAccount = (address: string): boolean => {
-  if (!address) return false
-  return (
-    /^[0-9a-f]{64}$/.test(address) ||
-    /^0x[0-9a-f]{40}$/.test(address) ||
-    /^0s[0-9a-f]{40}$/.test(address)
-  )
+export const NEAR_ACCOUNT_ID_PATTERN =
+  /^(?=.{2,64}$)(?:(?:[a-z0-9]+[-_])*[a-z0-9]+\.)*(?:[a-z0-9]+[-_])*[a-z0-9]+$/
+
+export const isValidNearAccount = (accountId: string): boolean => {
+  if (!accountId) return false
+  return NEAR_ACCOUNT_ID_PATTERN.test(accountId)
 }
 
 /**
@@ -22,7 +20,7 @@ export const isImplicitAccount = (address: string): boolean => {
 export const detectNetworkFromAddress = (
   contractAddress: string
 ): NetworkType | null => {
-  if (!contractAddress) return null
+  if (!isValidNearAccount(contractAddress)) return null
 
   if (contractAddress.endsWith('.near')) {
     return 'mainnet'
@@ -32,17 +30,4 @@ export const detectNetworkFromAddress = (
 
   // Implicit and deterministic accounts can exist on either network
   return null
-}
-
-/**
- * Checks if a contract address is a valid NEAR account identifier.
- * Accepts named accounts (.near/.testnet) and implicit/deterministic accounts.
- */
-export const isValidNearAccount = (contractAddress: string): boolean => {
-  if (!contractAddress) return false
-  return (
-    contractAddress.endsWith('.near') ||
-    contractAddress.endsWith('.testnet') ||
-    isImplicitAccount(contractAddress)
-  )
 }


### PR DESCRIPTION
## Summary

- Replace the frontend suffix-only account gate with the same full NEAR account-id pattern used by the verifier backend.
- Keep network auto-detection limited to valid account IDs, returning null for implicit/deterministic/root accounts where the network cannot be inferred from a suffix.
- Guard account-dependent RPC effects so invalid route params do not reach the data-fetching path, and update invalid-account UI text.

## Validation

- Disposable Docker container, repo mounted read-only then copied inside: npm ci --ignore-scripts --no-audit --no-fund
- Docker-only account validation smoke against the exact TypeScript helper: named accounts, root accounts, 64-char implicit, 0x/0s deterministic, malformed .near strings, uppercase, spacing, semicolon, and length rejection
- npm run lint
- npm run build
- git diff --check